### PR TITLE
feat(profile): rewrite for current product (fleet operations) + SEO + contributors placeholder

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,106 +1,96 @@
-<h1 align="center">Scadable</h1>
-<p align="center"><em>SCADA that doesn't suck.</em></p>
-<p align="center">Your data. Your control. Anywhere.</p>
-
-
-
-**Scadable** is a next-generation **SCADA-as-a-Service** platform built for the modern industrial world. We deliver powerful monitoring and control capabilities through a cloud-native, API-first model, eliminating the complexity and cost of traditional on-premises systems.
-
-Our mission is to empower developers and operators to innovate without the burden of infrastructure.
-
-
-
-## ❌ The Problem with Traditional SCADA
-
-Legacy SCADA systems are holding businesses back. They are typically:
-
-* **Monolithic & Inflexible:** Locked into proprietary, on-premise hardware that is difficult to scale or customize.
-* **Expensive:** Burdened by high upfront licensing costs, per-tag fees, and constant maintenance.
-* **Slow & Complex:** Require specialized OT expertise, slowing down integration and innovation.
-* **Siloed:** Keep critical data trapped, preventing access for modern analytics and custom applications.
-
-
-
-## ✅ Why Scadable is Different
-
-Scadable breaks down these barriers with a flexible, developer-centric approach.
-
-| Feature                          | Benefit                                                                                               |
-| :------------------------------- | :---------------------------------------------------------------------------------------------------- |
-| **Cloud-Native & API-First** | Build custom workflows and integrate with any tool. No vendor lock-in.                                |
-| **Guaranteed 24/7 Uptime** | Our multi-region architecture ensures your operations are always online, without you managing servers.  |
-| **Dynamic Scaling** | Resources scale automatically to meet demand, ensuring smooth performance from one device to thousands. |
-| **Pay-As-You-Go Pricing** | Transparent, consumption-based pricing. No surprise per-tag fees or expensive upfront licenses.        |
-| **Programmable Pipelines** | Automate complex sequences—like data collection, analysis, and control commands—with simple API calls. |
-| **Decoupled Architecture** | Your business logic stays in your application, not locked in the SCADA. This means lower latency and simpler upgrades. |
-
-
-
-## 🏗️ How It Works: System Architecture
-
-Our platform is designed to be a flexible service layer that connects to your devices and empowers your applications.
-
-<img alt="image" src="https://github.com/user-attachments/assets/f242070b-1790-4c49-b072-aafa2fd01042" />
-
-
-
-## 🚀 Who We're For
-
-* **Industrial Operators** who need reliable, real-time visibility and control from anywhere.
-* **Developers & Engineers** who want to build custom IoT applications and workflows without deep OT expertise.
-* **Business Leaders** looking to modernize operations, reduce CapEx, and unlock data for smarter decisions.
-
-## ✨ Our Contributors
-
-This project is made possible by the following amazing people.
-
-| Full Name | GitHub Username | GitHub Profile |
-| :--- | :--- | :--- |
-| **Ali Rahbar** | `crypto-a` | [View Profile](https://github.com/crypto-a) |
-| **Christopher Li** | `ChristopherLi05` | [View Profile](https://github.com/ChristopherLi05) |
-| **Neyl Nasr** | `Lakssito` | [View Profile](https://github.com/Lakssito) |
-| **Benjamin Gavriely** | `Benjamin-Uoft` | [View Profile](https://github.com/Benjamin-Uoft) |
-| **Matteo Gentili** | `MatteoGentili24` | [View Profile](https://github.com/MatteoGentili24) |
-| **Azaria Kelman** | `azariak` | [View Profile](https://github.com/azariak) |
-| **Daniel Rafailov** | `danielrafailov1` | [View Profile](https://github.com/danielrafailov1) |
-
-## 📦 Our Repositories
-
-Explore the various components that power the Scadable platform.
-
-| Repository | Description | Link |
-| :--- | :--- | :--- |
-| **library-python** | Python SDK for Scadable platform integration | [View Repository](https://github.com/scadable/library-python) |
-| **library-react** | React component library for Scadable applications | [View Repository](https://github.com/scadable/library-react) |
-| **decoder-repo** | Device data decoder utilities and protocols | [View Repository](https://github.com/scadable/decoder-repo) |
-| **web-main** | Main web application frontend | [View Repository](https://github.com/scadable/web-main) |
-| **web-dashboard** | Real-time monitoring and control dashboard | [View Repository](https://github.com/scadable/web-dashboard) |
-| **web-docs** | Platform documentation website | [View Repository](https://github.com/scadable/web-docs) |
-| **infrastructure-platform** | Infrastructure as Code for platform deployment | [View Repository](https://github.com/scadable/infrastructure-platform) |
-| **service-api** | Main API gateway service | [View Repository](https://github.com/scadable/service-api) |
-| **service-auth** | Authentication and authorization service | [View Repository](https://github.com/scadable/service-auth) |
-| **service-device** | Device management and connectivity service | [View Repository](https://github.com/scadable/service-device) |
-| **service-facility** | Facility and asset management service | [View Repository](https://github.com/scadable/service-facility) |
-| **service-mqtt** | MQTT broker service for device communication | [View Repository](https://github.com/scadable/service-mqtt) |
-| **service-orchestrator** | Service orchestration and coordination | [View Repository](https://github.com/scadable/service-orchestrator) |
-| **service-faas** | Functions as a Service runtime engine | [View Repository](https://github.com/scadable/service-faas) |
-| **worker-faas** | FaaS worker execution processes | [View Repository](https://github.com/scadable/worker-faas) |
-| **service-agentics** | AI agent service for intelligent automation | [View Repository](https://github.com/scadable/service-agentics) |
-| **service-decoder** | Data decoding and transformation service | [View Repository](https://github.com/scadable/service-decoder) |
-| **service-historian** | Time-series data storage and retrieval | [View Repository](https://github.com/scadable/service-historian) |
-| **service-live-query** | Real-time data query service | [View Repository](https://github.com/scadable/service-live-query) |
-| **service-notification** | Multi-channel notification service | [View Repository](https://github.com/scadable/service-notification) |
-
-## 🏁 Get Started
-
-Ready to see the future of industrial control? Dive into our documentation or visit our website to learn more.
+<h1 align="center">SCADABLE</h1>
+<p align="center"><em>Your hardware fleet, managed from your codebase.</em></p>
 
 <p align="center">
-  <a href="https://docs.scadable.com" style="display:inline-block; margin: 10px; padding:12px 24px; background-color:#007BFF; color:white; border-radius:6px; text-decoration:none; font-weight:bold;">
-    📖 Read the Docs
-  </a>
-  <a href="https://scadable.com" style="display:inline-block; margin: 10px; padding:12px 24px; background-color:#28A745; color:white; border-radius:6px; text-decoration:none; font-weight:bold;">
-    🌐 Visit Scadable.com
-  </a>
+  <a href="https://scadable.com">scadable.com</a> ·
+  <a href="https://docs.scadable.com">docs.scadable.com</a> ·
+  <a href="https://dashboard.scadable.com">dashboard.scadable.com</a>
 </p>
 
+---
+
+SCADABLE is the infrastructure layer between connected hardware and the cloud. Medical, industrial, energy, and ag-tech teams use it to ship a connected product without becoming a cloud company — push firmware to your repo, the fleet rolls out, telemetry streams in, and a PR opens when something needs fixing.
+
+## What you get on day one
+
+- **Faster time-to-market.** Skip the 12–18 month detour of building your own IoT stack. Push a tag in the repo you already have; SCADABLE builds, signs, and ships the firmware to every device in the fleet.
+- **Lower operational risk.** mTLS per device, automatic certificate rotation (EST), signed OTA with A/B partitions, post-OTA diagnostic verification, and auto-rollback if any sensor health check fails. The scariest thing you ship — firmware updates — becomes boring.
+- **Compliance-ready by default.** SOC 2-aligned immutable audit log (13-month retention), per-tenant isolation, FDA cybersecurity-compatible patterns, HIPAA-compatible architecture. Designed for the hospital procurement review, not against it.
+
+## What SCADABLE actually does
+
+You write firmware in your language — C, C++, Rust, Arduino — and link [`libscadable`](https://github.com/scadable/libscadable). You push to GitHub. The SCADABLE GitHub App reads your `.scadable/` config, builds and signs a release, and rolls it out to the fleet.
+
+Devices come online over mTLS. Telemetry streams through the platform's MQTT broker into the time-series historian. Logs, metrics, and live diagnostics show up in the dashboard at [dashboard.scadable.com](https://dashboard.scadable.com). Every state change is recorded in an immutable audit log.
+
+After every OTA, the platform runs the diagnostics you declared in `.scadable/diagnostics/*.yaml` against each gateway in the rollout. If `motor_health` fails on one device out of a thousand, the release is marked `verification_failed` and that gateway auto-rolls back to the previous good firmware — before the bad release reaches the rest of the fleet.
+
+ESP32 and ESP32-S3 are production today. Linux gateways (x86_64, aarch64, armv7) for industrial Debian boxes, Raspberry Pi, and edge servers ship from `gateway-linux`. RTOS targets are on the roadmap.
+
+## Deployment-ready in minutes
+
+Everything you need to operate a connected hardware fleet, working out of the box:
+
+- mTLS device identity and automatic certificate rotation (EST `simplereenroll`)
+- Signed OTA with A/B partition rollback
+- Post-OTA diagnostic verification with auto-rollback on failure
+- MQTT broker with topic-level ACLs and offline telemetry buffering
+- Time-series historian with retention rules
+- SOC 2-aligned immutable audit log (13-month retention)
+- Multi-tenant isolation, multi-cluster ready from day one
+- Web dashboard with live telemetry, OTA controls, diagnostic runs, audit history
+- GitHub App integration — push a tag, fleet rolls out
+
+The fast path:
+
+```bash
+pip install scadable
+scadable verify          # validate your .scadable/ config
+```
+
+Connect your repo via the [SCADABLE GitHub App](https://github.com/apps/scadable), pick a starter ([arduino-platformio-starter](https://github.com/scadable/arduino-platformio-starter)), push a tag, watch the fleet update.
+
+## Public repositories
+
+| Repository | What it is |
+| :--- | :--- |
+| [**libscadable**](https://github.com/scadable/libscadable) | The C library devices link against. ESP-IDF Component Registry: `crypto-a/libscadable` |
+| [**arduino-platformio-starter**](https://github.com/scadable/arduino-platformio-starter) | Fastest path to a first device. PlatformIO + Arduino, `.scadable/` pre-wired |
+| [**gateway-provisioning**](https://github.com/scadable/gateway-provisioning) | In-browser WebSerial flasher and captive-portal provisioning for new gateways |
+
+Service code (broker, control plane, dashboard, historian, orchestrator) lives in private repos. The [docs at docs.scadable.com](https://docs.scadable.com) are the public reference.
+
+## Links
+
+- **Marketing site:** [scadable.com](https://scadable.com)
+- **Documentation:** [docs.scadable.com](https://docs.scadable.com)
+- **Dashboard:** [dashboard.scadable.com](https://dashboard.scadable.com)
+- **Talk to us:** [cal.com/rahbaral/quick-chat](https://cal.com/rahbaral/quick-chat)
+
+## Contributors
+
+SCADABLE began as a university course project. The platform has evolved substantially since then — different architecture, different market, different product — but the original team's work seeded what SCADABLE is today, and they deserve credit for it.
+
+<!--
+Ali: fill in / confirm names below, then strip these comment markers so the
+section renders publicly. Pre-pivot list (already public on the live profile)
+is preserved here as a starting point — edit, reorder, or replace freely.
+
+### Original course-project team
+- **Ali Rahbar** — [@crypto-a](https://github.com/crypto-a)
+- **Christopher Li** — [@ChristopherLi05](https://github.com/ChristopherLi05)
+- **Neyl Nasr** — [@Lakssito](https://github.com/Lakssito)
+- **Benjamin Gavriely** — [@Benjamin-Uoft](https://github.com/Benjamin-Uoft)
+- **Matteo Gentili** — [@MatteoGentili24](https://github.com/MatteoGentili24)
+- **Azaria Kelman** — [@azariak](https://github.com/azariak)
+- **Daniel Rafailov** — [@danielrafailov1](https://github.com/danielrafailov1)
+
+### Current core team
+- **Ali Rahbar** — Founder, CTO — [@crypto-a](https://github.com/crypto-a)
+-->
+
+<p align="center">
+  <a href="https://scadable.com">scadable.com</a> ·
+  <a href="https://docs.scadable.com">docs.scadable.com</a> ·
+  <a href="https://dashboard.scadable.com">dashboard.scadable.com</a>
+</p>


### PR DESCRIPTION
## What changed

Rewrote `profile/README.md` from the v3 SCADA-as-a-Service positioning to the current fleet-operations product. The previous content described services that no longer exist (`service-auth`, `service-faas`, `library-python`) and pitched a category we've moved off of.

## Why

Per Ali: the org profile at `github.com/scadable` is publicly indexed and is one of our better organic surfaces while `scadable.com` is still climbing. Three goals for this rewrite:

1. **Product accuracy** — describe what actually ships today (libscadable + GitHub App + post-OTA diagnostic verification with auto-rollback), not what shipped 18 months ago.
2. **Voice match with `web-main`** — direct, founder, second-person, no "platform/seamless/empower" per `web-main/docs/03-positioning.md`. Same hero framing as the marketing site ("Your hardware fleet, managed from your codebase").
3. **SEO** — target the validated long-tail keywords from `web-main/docs/04-seo-strategy.md`: "IoT fleet operations / fleet management", "OTA firmware update", "connected hardware", "build vs buy IoT", "mTLS device identity". Written for humans first; no keyword stuffing.

## Hero benefits (Ali's three)

- Faster time-to-market (vs building your own IoT stack)
- Lower operational risk (mTLS, signed OTA, audit log, post-OTA verification with auto-rollback)
- Compliance-ready (SOC 2-aligned immutable audit, FDA cybersecurity-compatible, multi-tenant)

## Contributors section

Per Ali's brief: an HTML-commented placeholder. The pre-pivot course-project team list (already public on the live profile) is preserved inside the comment as a starting point so he can confirm/reorder/edit, then strip the `<!--` / `-->` markers to publish. Until then, the section heading + intro paragraph render publicly but the names stay private to the file.

## Public repos linked

Only the three actually-public repos: `libscadable`, `arduino-platformio-starter`, `gateway-provisioning`. Internal services are deliberately not listed.

## Verification

- No CI on this repo. Confirmed via `ls .github/workflows/` (none).
- Default branch is `main`. Will squash-merge.
- Author: Ali Rahbar / `alirahbar2005@gmail.com` per AGENT-METHODOLOGY.md §1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)